### PR TITLE
Reuse workflows - second attempt!

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,8 +8,8 @@ on:
         default: Dockerfile
 
 jobs:
-
   docker-build:
+    name: Build docker
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   bump-version:
+    name: Bump version
     runs-on: ubuntu-latest
     outputs:
       new_ver: ${{ steps.bumper.outputs.new_ver }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,16 +1,25 @@
+# Bump the version of the repo and push the new version in a new commit.
+
 name: Bump version
+
+on:
+  workflow_call:
+    outputs:
+      new_ver:
+        description: New version number
+        value: ${{ jobs.bump-version.outputs.new_ver }}
 
 
 jobs:
-  build:
+  bump-version:
     runs-on: ubuntu-latest
     outputs:
-      new_tag: ${{ steps.bumper.outputs.new_ver }}
+      new_ver: ${{ steps.bumper.outputs.new_ver }}
     steps:
       - uses: actions/checkout@v2
       - name: Bump version and push tag
         id: bumper
-        uses: jasonamyers/github-bumpversion-action@v1.0.3
+        uses: jasonamyers/github-bumpversion-action@v1.0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push changes

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,4 +1,9 @@
+# Shortcut that runs both
+# * bump-version.yml
+# * push-docker.yml
+
 name: Bump version and auto-release
+
 on:
   workflow_call:
     secrets:
@@ -17,61 +22,13 @@ on:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-latest
-    outputs:
-      new_tag: ${{ steps.bumper.outputs.new_ver }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Bump version
-        id: bumper
-        uses: jasonamyers/github-bumpversion-action@v1.0.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
+    uses: openclimatefix/.github/.github/workflows/bump-version.yml@v1.2.0
 
   docker-release:
     needs: [bump-version]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: main
-      - run: echo ${{ needs.bump-version.outputs.new_tag }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          # list of Docker images to use as base name for tags
-          # TODO make more flexible
-          images: |
-            openclimatefix/${{ inputs.image_base_name }}
-          tags: |
-            type=raw,value=${{ needs.bump-version.outputs.new_tag }}
-          flavor: |
-            latest=true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: openclimatefix
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ${{ inputs.docker_file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    uses: openclimatefix/.github/.github/workflows/push-docker.yml@v1.2.0
+    with:
+      image_base_name: ${{inputs.image_base_name}}
+      docker_file: ${{inputs.docker_file}}
+      tag_value: ${{ needs.bump-version.outputs.new_ver }}
+    secrets: inherit

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,39 @@
+name: Make a github release
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        # This default value is consistent with the actions/checkout default value.
+        # Note however that if this is called after, say, the bump-version workflow, then
+        # this won't point to the right commit: use `main` instead in that case.
+        default: ${{ github.sha }}
+        type: string
+      version:
+        description: Version to release, e.g. "1.0.0"
+        type: string
+        required: true
+
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ inputs.version }}
+          release_name: v${{ inputs.version }}
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -3,12 +3,6 @@ name: Make a github release
 on:
   workflow_call:
     inputs:
-      ref:
-        # This default value is consistent with the actions/checkout default value.
-        # Note however that if this is called after, say, the bump-version workflow, then
-        # this won't point to the right commit: use `main` instead in that case.
-        default: ${{ github.sha }}
-        type: string
       version:
         description: Version to release, e.g. "1.0.0"
         type: string
@@ -17,6 +11,7 @@ on:
 
 jobs:
   github-release:
+    name: Github release
     runs-on: ubuntu-latest
     steps:
       - name: Changelog

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,43 @@
+name: Publish python package to PYPI
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        # This default value is consistent with the actions/checkout default value.
+        # Note however that if this is called after, say, the bump-version workflow, then
+        # this won't point to the right commit: use `main` instead in that case.
+        default: ${{ github.sha }}
+        type: string
+    secrets:
+      token:
+        required: true
+
+
+jobs:
+  publish-python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.token }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   publish-python:
+    name: Publish to PYPI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -1,0 +1,72 @@
+name: Build and publish to Docker Hub
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+    inputs:
+      image_base_name:
+        required: true
+        type: string
+      docker_file:
+        required: false
+        type: string
+        default: Dockerfile
+      tag_value:
+        required: true
+        type: string
+      checkout_submodules:
+        description: Forwarded to `submodule` input of the `actions/checkout` step.
+        type: boolean
+        required: false
+        # Default: false
+        # See: https://github.com/actions/checkout/tree/v2
+        default: false
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Using `main` because so far this has always been done *after* a bump-version, which adds
+          # a commit on top of the default commit to which the action would be otherwise pointing.
+          ref: main
+          submodules: ${{ inputs.checkout_submodules }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          # TODO make more flexible
+          images: |
+            openclimatefix/${{ inputs.image_base_name }}
+          tags: |
+            type=raw,value=${{ inputs.tag_value }}
+          flavor: |
+            latest=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: openclimatefix
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ inputs.docker_file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -27,7 +27,8 @@ on:
         default: false
 
 jobs:
-  docker-release:
+  push-docker:
+    name: Push docker @ ${{ inputs.tag_value }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/python-docker-release.yml
+++ b/.github/workflows/python-docker-release.yml
@@ -1,3 +1,9 @@
+# Shortcut to run the following:
+# * bump-version.yml
+# * publish-to-pypi.yml
+# * github-release.yml
+# * push-docker.yml
+
 name: Bump version and auto-release
 on:
   workflow_call:
@@ -18,100 +24,28 @@ on:
         default: Dockerfile
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    outputs:
-      new_tag: ${{ steps.bumper.outputs.new_ver }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Bump version and push tag
-        id: bumper
-        uses: jasonamyers/github-bumpversion-action@v1.0.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.token }}
+  bump-version:
+    uses: openclimatefix/.github/.github/workflows/bump-version.yml@v1.2.0
 
-  python-release:
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ${{needs.build.outputs.new_tag}}
-      - name: Changelog
-        uses: scottbrenner/generate-changelog-action@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ needs.build.outputs.new_tag }}
-          release_name: v${{ needs.build.outputs.new_tag }}
-          body: |
-            ${{ steps.Changelog.outputs.changelog }}
-          draft: false
-          prerelease: false
+  publish-to-pypi:
+    needs: [bump-version]
+    uses: openclimatefix/.github/.github/workflows/publish-to-pypi.yml@v1.2.0
+    with:
+      # We need this because we want to use the new commits from the `bump-version` job.
+      ref: main
+    secrets: inherit
+
+  github-release:
+    needs: [bump-version]
+    uses: openclimatefix/.github/.github/workflows/github-release.yml@v1.2.0
+    with:
+      version: ${{ needs.bump-version.outputs.new_ver }}
 
   docker-release:
-    needs: [build, python-release]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: main
-      - run: echo ${{ needs.build.outputs.new_tag }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          # list of Docker images to use as base name for tags
-          # TODO make more flexible
-          images: |
-            openclimatefix/${{ inputs.image_base_name }}
-          tags: |
-            type=raw,value=${{ needs.build.outputs.new_tag }}
-          flavor: |
-            latest=true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: openclimatefix
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ${{ inputs.docker_file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    needs: [bump-version]
+    uses: openclimatefix/.github/.github/workflows/push-docker.yml@v1.2.0
+    with:
+      image_base_name: ${{inputs.image_base_name}}
+      docker_file: ${{inputs.docker_file}}
+      tag_value: ${{ needs.bump-version.outputs.new_ver }}
+    secrets: inherit

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,98 +1,30 @@
+# Shortcut to run the following:
+# * bump-version.yml
+# * publish-to-pypi.yml
+# * github-release.yml
+
 name: Bump version and auto-release
+
 on:
   workflow_call:
-    inputs:
-      workdir:
-        description: 'The directory of the root of the python project'
-        default: '.'
-        required: false
-        type: string
     secrets:
       token:
         required: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.workdir }}
+  bump-version:
+    uses: openclimatefix/.github/.github/workflows/bump-version.yml@v1.2.0
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build
+  publish-to-pypi:
+    needs: [bump-version]
+    uses: openclimatefix/.github/.github/workflows/publish-to-pypi.yml@v1.2.0
+    with:
+      # We need this because we want to use the new commits from the `bump-version` job.
+      ref: main
+    secrets: inherit
 
-  publish:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.workdir }}
-    needs: ["build"]
-    outputs:
-      new_tag: ${{ steps.bumper.outputs.new_ver }}
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-            fetch-depth: 0
-            token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Bump version
-        id: bumper
-        uses: jasonamyers/github-bumpversion-action@v1.0.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE: ${{ inputs.workdir }}
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: python -m build
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.token }}
-          packages_dir: ${{ inputs.workdir }}/dist
-
-  release:
-    needs: [publish]
-    runs-on: ubuntu-latest
-
-    steps:
-      - run: echo ${{needs.publish.outputs.new_tag}}
-      - name: Changelog
-        uses: scottbrenner/generate-changelog-action@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ needs.publish.outputs.new_tag }}
-          release_name: v${{ needs.publish.outputs.new_tag }}
-          body: |
-            ${{ steps.Changelog.outputs.changelog }}
-          draft: false
-          prerelease: false
+  github-release:
+    needs: [bump-version]
+    uses: openclimatefix/.github/.github/workflows/github-release.yml@v1.2.0
+    with:
+      version: ${{ needs.bump-version.outputs.new_ver }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,11 +25,6 @@ on:
         default: '["ubuntu-latest", "macos-latest"]'
         type: string
         required: false
-      workdir:
-        description: 'The directory of the root of the python project'
-        default: '.'
-        required: false
-        type: string
       python-version:
         description: 'The python versions to use'
         default: "['3.9', '3.10']"
@@ -50,9 +45,6 @@ jobs:
         python-version: ${{ fromJson(inputs.python-version) }}
         os: "${{ fromJSON(inputs.os_list) }}"
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: ${{ inputs.workdir }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Background

This is very similar to #36 which turned out to break in some places and was reverted in #37. Here I fix the issue and extract even more steps into reusable workflows.

The issue was that we were checking out the code *before* the version bump commit. When one job creates a new commit, we must checkout `main` explicitly, otherwise it defaults to the last commit at the time the workflow was started.

# Description

Instead of copy pasting a lot of code between workflows, we reuse simpler workflows. These are new:

* bump-version
* github-release
* publish-to-pypi
* push-docker

Also:
* Relax the job dependencies in the workflows: only `bump-version` needs to be done before the other ones. This means more parallelism.
* Support submodules in docker-release-only workflow
* Rename "new_tag" -> "new_ver"
* Bump jasonamyers/github-bumpversion-action to 1.0.5
* Uniformize job names
* Remove `workdir` option (it wasn't used anywhere)

This should in theory be fully backward compatible with 1.0.0.

# Tests
- [x] Everything runs in [.github-test][3]
- [x] It works with [pv-site-production][2] (it is currently broken)
- [x] It works with [Satip][1] (was broken last time)

[1]: https://github.com/openclimatefix/Satip
[2]: https://github.com/openclimatefix/pv-site-production
[3]: https://github.com/openclimatefix/.github-test