### PR TITLE
Bump secret

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -9,7 +9,7 @@ on:
         description: New version number
         value: ${{ jobs.bump-version.outputs.new_ver }}
     secrets:
-      token:
+      TOKEN_SECRET_KEY:
         required: true
 
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Bump version and push tag
         id: bumper
         uses: jasonamyers/github-bumpversion-action@v1.0.5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -8,6 +8,9 @@ on:
       new_ver:
         description: New version number
         value: ${{ jobs.bump-version.outputs.new_ver }}
+    secrets:
+      token:
+        required: true
 
 
 jobs:
@@ -19,19 +22,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
+        secrets:
           token: ${{ secrets.TOKEN_SECRET_KEY }}
 
       - name: Bump version and push tag
         id: bumper
         uses: jasonamyers/github-bumpversion-action@v1.0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN_SECRET_KEY }}
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.TOKEN_SECRET_KEY }}
           tags: true
           force: true
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.TOKEN_SECRET_KEY }}
 
       - name: Bump version and push tag
         id: bumper

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,7 +18,7 @@ jobs:
       new_ver: ${{ steps.bumper.outputs.new_ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ssh-key: ${{secrets.TOKEN_GITHUB_SECRET_KEY}}
       - name: Bump version and push tag

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{secrets.TOKEN_GITHUB_SECRET_KEY}}
           tags: true

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        secrets:
+        with:
           token: ${{ secrets.TOKEN_SECRET_KEY }}
 
       - name: Bump version and push tag

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,3 +31,4 @@ jobs:
         with:
           ssh-key: ${{secrets.TOKEN_GITHUB_SECRET_KEY}}
           tags: true
+          force: true

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ssh-key: ${{secrets.TOKEN_GITHUB_SECRET_KEY}}
+          ssh-key: ${{secrets.TOKEN_SECRET_KEY}}
       - name: Bump version and push tag
         id: bumper
         uses: jasonamyers/github-bumpversion-action@v1.0.5

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,24 +23,14 @@ jobs:
       - name: Bump version and push tag
         id: bumper
         uses: jasonamyers/github-bumpversion-action@v1.0.5
-
-      - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@master
-        if: always()
-        with:
-          access_token: ${{ secrets.TOKEN_SECRET_KEY }}
-          branch: ${{ github.event.repository.default_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          ssh: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
           force: true
 
-      - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@master
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.TOKEN_SECRET_KEY }}
-          branch: ${{ github.event.repository.default_branch }}
+

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,10 @@ jobs:
     outputs:
       new_ver: ${{ steps.bumper.outputs.new_ver }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{secrets.TOKEN_GITHUB_SECRET_KEY}}
       - name: Bump version and push tag
         id: bumper
         uses: jasonamyers/github-bumpversion-action@v1.0.5

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          ssh-key: ${{secrets.TOKEN_GITHUB_SECRET_KEY}}
+          ssh: true
           tags: true
           force: true

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,14 +19,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ssh-key: ${{secrets.TOKEN_SECRET_KEY}}
+
       - name: Bump version and push tag
         id: bumper
         uses: jasonamyers/github-bumpversion-action@v1.0.5
+
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@master
+        if: always()
+        with:
+          access_token: ${{ secrets.TOKEN_SECRET_KEY }}
+          branch: ${{ github.event.repository.default_branch }}
+
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           ssh: true
           tags: true
           force: true
+
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@master
+        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.TOKEN_SECRET_KEY }}
+          branch: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   bump-version:
-    uses: openclimatefix/.github/.github/workflows/bump-version.yml@bump-version
+    uses: openclimatefix/.github/.github/workflows/bump-version.yml@bump-secret
 
   docker-release:
     needs: [bump-version]

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -24,6 +24,7 @@ jobs:
   bump-version:
     # temp branch name
     uses: openclimatefix/.github/.github/workflows/bump-version.yml@bump-secret
+    secrets: inherit
 
   docker-release:
     needs: [bump-version]

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   bump-version:
+    # temp branch name
     uses: openclimatefix/.github/.github/workflows/bump-version.yml@bump-secret
 
   docker-release:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,6 +11,8 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
+      TOKEN_SECRET_KEY:
+        required: true
     inputs:
       image_base_name:
         required: true

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   bump-version:
-    uses: openclimatefix/.github/.github/workflows/bump-version.yml@v1.2.0
+    uses: openclimatefix/.github/.github/workflows/bump-version.yml@bump-version
 
   docker-release:
     needs: [bump-version]


### PR DESCRIPTION
# Pull Request

## Description

If we add a github branch protection, then for `bump version` to work, we need to pass through a Github personal token. 

## How Has This Been Tested?

Tested it with GSP Consumer and it worked

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
