### PR TITLE
Add test directory option

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -40,6 +40,11 @@ on:
         default: ''
         type: string
         required: false
+      test_dir:
+        # Test directory to go into (if needed)
+        default: ''
+        type: string
+        required: false
 
 
 
@@ -110,6 +115,7 @@ jobs:
           export PYTHONPATH=${PYTHONPATH}:${{ inputs.python_path }}
           export PYTEST_COMMAND="pytest $PYTESTCOV $PYTESTXDIST -s"
           echo "Will be running this command: $PYTEST_COMMAND"
+          if [ ${{ inputs.test_dir }} != '' ]; then cd ${{ inputs.test_dir }}; fi
           eval $PYTEST_COMMAND
       - name: Show coverage
         run: coverage report -m


### PR DESCRIPTION
Add test directory option

# Pull Request

## Description

Adds option for test directory to move into during python tests.

Fixes issue with https://github.com/openclimatefix/uk-pv-national-xg/pull/74 where pytest doesn't find the tests unless its in a specific directory

## How Has This Been Tested?

In https://github.com/openclimatefix/uk-pv-national-xg/pull/74

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
