### PR TITLE
add discssion link to main company readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,6 @@ Here's how you can get involved:
 * **Before you submit a pull request**, please ask to be assigned to the issue! Some issues are there for us to get back to and unfortunately might be completely inaccessible to OS contribution. Asking to be assigned first will prevent you from doing unnecessary work and lets everybody else know you're working on this already, so we don't get multiple PRs for the same issue;
 * Once you're assigned to an issue, submit your PR and tag someone for a review! Our coding style is [here](https://github.com/openclimatefix/.github/blob/main/coding_style.md);
 * First time contributing? Here's a [quick guide from firstcontributions](https://github.com/firstcontributions/first-contributions) to help you get started!
-
 * Join our [GitHub Discussions](https://github.com/orgs/openclimatefix/discussions) to ask questions, share ideas, or engage with the community.
 
 ### Other ways to get involved
@@ -28,8 +27,6 @@ Here's how you can get involved:
 * Spread the word with your networks;
 * Already contributed? Add OCF to the skills or volunteering section of your LinkedIn!
 * Use our code(!) by following the guidelines below.
-
-
 <details><summary><a>
   <h2>What if you use our code?</h2> <small>[ Click to expand ]</small>
 </a></summary>
@@ -55,7 +52,6 @@ We've set up this traffic light legend, so you can see how easy it is to get inv
 | [![ease of contribution: hard](https://img.shields.io/badge/ease%20of%20contribution:%20hard-bb2629)](https://github.com/openclimatefix#how-easy-is-it-to-get-involved) | We would not recommend going into these projects. They haven't been made "nice" and it might take a lot of digging in the code to understand what's going on.      |
 
 You will usually see one of the corresponding badges on the repo's README.
-
 
 ## Overview of OCF's repositories
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,6 +19,7 @@ Here's how you can get involved:
 * Once you're assigned to an issue, submit your PR and tag someone for a review! Our coding style is [here](https://github.com/openclimatefix/.github/blob/main/coding_style.md);
 * First time contributing? Here's a [quick guide from firstcontributions](https://github.com/firstcontributions/first-contributions) to help you get started!
 * Join our [GitHub Discussions](https://github.com/orgs/openclimatefix/discussions) to ask questions, share ideas, or engage with the community.
+
 ### Other ways to get involved
 * Sign up to our [newsletter](https://ocfnews.substack.com/?utm_source=substack&utm_medium=web&utm_campaign=substack_profile) and follow us on [Bluesky](https://bsky.app/profile/openclimatefix.org) and [LinkedIn](https://www.linkedin.com/company/19123036/admin/) to learn the latest about our work;
 * Use our datasets on [Hugging Face](https://huggingface.co/openclimatefix) or [EUMETSAT satellite data](https://console.cloud.google.com/marketplace/product/bigquery-public-data/eumetsat-seviri-rss?hl=en-GB&project=solar-pv-nowcasting) and let us know if it was useful;

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,6 @@ Here's how you can get involved:
 * Once you're assigned to an issue, submit your PR and tag someone for a review! Our coding style is [here](https://github.com/openclimatefix/.github/blob/main/coding_style.md);
 * First time contributing? Here's a [quick guide from firstcontributions](https://github.com/firstcontributions/first-contributions) to help you get started!
 * Join our [GitHub Discussions](https://github.com/orgs/openclimatefix/discussions) to ask questions, share ideas, or engage with the community.
-
 ### Other ways to get involved
 * Sign up to our [newsletter](https://ocfnews.substack.com/?utm_source=substack&utm_medium=web&utm_campaign=substack_profile) and follow us on [Bluesky](https://bsky.app/profile/openclimatefix.org) and [LinkedIn](https://www.linkedin.com/company/19123036/admin/) to learn the latest about our work;
 * Use our datasets on [Hugging Face](https://huggingface.co/openclimatefix) or [EUMETSAT satellite data](https://console.cloud.google.com/marketplace/product/bigquery-public-data/eumetsat-seviri-rss?hl=en-GB&project=solar-pv-nowcasting) and let us know if it was useful;

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ Here's how you can get involved:
 * Once you're assigned to an issue, submit your PR and tag someone for a review! Our coding style is [here](https://github.com/openclimatefix/.github/blob/main/coding_style.md);
 * First time contributing? Here's a [quick guide from firstcontributions](https://github.com/firstcontributions/first-contributions) to help you get started!
 
-* Join our [GitHub Discussions](https://github.com/orgs/openclimatefix/discussions/new/choose) to ask questions, share ideas, or engage with the community.
+* Join our [GitHub Discussions](https://github.com/orgs/openclimatefix/discussions) to ask questions, share ideas, or engage with the community.
 
 ### Other ways to get involved
 * Sign up to our [newsletter](https://ocfnews.substack.com/?utm_source=substack&utm_medium=web&utm_campaign=substack_profile) and follow us on [Bluesky](https://bsky.app/profile/openclimatefix.org) and [LinkedIn](https://www.linkedin.com/company/19123036/admin/) to learn the latest about our work;

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,6 +19,8 @@ Here's how you can get involved:
 * Once you're assigned to an issue, submit your PR and tag someone for a review! Our coding style is [here](https://github.com/openclimatefix/.github/blob/main/coding_style.md);
 * First time contributing? Here's a [quick guide from firstcontributions](https://github.com/firstcontributions/first-contributions) to help you get started!
 
+* Join our [GitHub Discussions](https://github.com/orgs/openclimatefix/discussions/new/choose) to ask questions, share ideas, or engage with the community.
+
 ### Other ways to get involved
 * Sign up to our [newsletter](https://ocfnews.substack.com/?utm_source=substack&utm_medium=web&utm_campaign=substack_profile) and follow us on [Bluesky](https://bsky.app/profile/openclimatefix.org) and [LinkedIn](https://www.linkedin.com/company/19123036/admin/) to learn the latest about our work;
 * Use our datasets on [Hugging Face](https://huggingface.co/openclimatefix) or [EUMETSAT satellite data](https://console.cloud.google.com/marketplace/product/bigquery-public-data/eumetsat-seviri-rss?hl=en-GB&project=solar-pv-nowcasting) and let us know if it was useful;


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a GitHub Discussions link to the "GitHub contributions" section under "How to get involved?". Specifically, I added the following bullet point:

→ Join our GitHub Discussions to ask questions, share ideas, or engage with the community.

This was inserted at the end of the existing list of GitHub contribution methods. The goal is to encourage more community engagement and provide an easy way for contributors to interact, ask questions, and collaborate within the Open Climate Fix community.

Fixes #64 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
