### PR TITLE
add hf token

### DIFF
--- a/.github/workflows/nondefault_branch_push_ci_python.yml
+++ b/.github/workflows/nondefault_branch_push_ci_python.yml
@@ -149,6 +149,8 @@ jobs:
       # * TODO: Work out how to pass environment variables to test
       - name: Run unit tests (with pytest)
         if: ${{ inputs.tests_runner != 'unittest' }}
+        env:
+           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
         run: uv run python -m pytest --junitxml=ut-report.xml ${{ inputs.tests_folder }}
       - name: Run unit tests (with unittest)
         if: ${{ inputs.tests_runner == 'unittest' }}


### PR DESCRIPTION
# Pull Request

## Description

add HF token when running pytest (if its there)

linked with https://github.com/openclimatefix/site-forecast-app/pull/13

## How Has This Been Tested?

- [x] tested on sites-forecast-app (still fixing other tests, but the token did get passed through)
- [x] checked on other repo that it didnt break

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
