### PR TITLE
Add --with ruff flag to prevent CI failures when ruff not in dependencies

### DIFF
--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Lint package
         if: ${{ inputs.enable_linting }}
         run: |
-          uv run ruff check --output-format=github .
+          uv run --with ruff ruff check --output-format=github .
 
       - name: Typecheck package
         if: ${{ inputs.enable_typechecking }}

--- a/.github/workflows/nondefault_branch_push_ci_python.yml
+++ b/.github/workflows/nondefault_branch_push_ci_python.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Lint package
         if: ${{ inputs.enable_linting }}
         run: |
-          uv run ruff check --output-format=github .
+          uv run --with ruff ruff check --output-format=github .
 
       - name: Typecheck package
         if: ${{ inputs.enable_typechecking }}


### PR DESCRIPTION
# Pull Request

## Description

Add `--with ruff` flag to ensure ruff is available during linting even when it's not included in a repository's requirements. This prevents CI failures in projects that don't have ruff as a dependency.

The issue suggested `uv run pip install ruff`, but I used `uv run —with ruff` instead because it's uv's built-in way to handle optional tools -no separate install step needed, just adds `--with ruff` to the existing command.

Fixes https://github.com/openclimatefix/.github/issues/87

## How Has This Been Tested?

Tested locally with `uv run --with ruff ruff check`:
  - Project WITHOUT ruff in dependencies - ruff gets installed on-demand
  - Project WITH ruff in dependencies - uses existing installation

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
