### PR TITLE
chore(branch-ci): Remove PYthon 3.10 from test matrix

### DIFF
--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -54,7 +54,7 @@ on:
         type: boolean
       test_python_versions:
         description: 'Which python verions to use'
-        default: '["3.10", "3.11", "3.12"]'
+        default: '["3.11", "3.12"]'
         type: string
         
 # Specify concurrency such that only one workflow can run at a time


### PR DESCRIPTION
Drops 3.10 from the test matrix in the branch CI. This is due to changes in the requirements of the OCF data sampler. If we are not intending to move away from 3.10, perhaps the requirement there should be relaxed, and this can be closed.