### PR TITLE
Work directory

### DIFF
--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -59,7 +59,7 @@ on:
       working_directory:
         description: >
           The working directory to run the workflow in.
-          Pass './' to run in the root of the repository.
+          Default is '.', the root of the repository.
         default: '.'
         required: false
         type: string


### PR DESCRIPTION
# Pull Request

## Description

Add "workgin directory" to branch_ci.yaml. This can be used if the pyproject.toml is not in the top level of a repo

Helps with https://github.com/openclimatefix/pv-site-production/pull/122

## How Has This Been Tested?

- tested in https://github.com/openclimatefix/pv-site-production/pull/122

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
