### PR TITLE
CI: allow passing HF_TOKEN to python-test workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,6 +2,14 @@ name: Python Tests
 on:
   workflow_call:
     inputs:
+      # Optional Hugging Face token.
+      # Callers can pass this as: secrets.HF_TOKEN
+      hf_token:
+        description: 'Optional Hugging Face token for tests'
+        required: false
+        type: string
+        default: ''
+
       pytest_cov_dir:
         required: false
         type: string
@@ -116,12 +124,15 @@ jobs:
           echo "pytest-cov options that will be used are: $PYTESTCOV"
           echo "PYTESTCOV=$PYTESTCOV" >> $GITHUB_ENV
       - name: Run pytest
+        env:
+          HF_TOKEN: ${{ inputs.hf_token }}
         run: |
           export PYTHONPATH=${PYTHONPATH}:${{ inputs.python_path }}
           export PYTEST_COMMAND="pytest $PYTESTCOV $PYTESTXDIST -s"
           echo "Will be running this command: $PYTEST_COMMAND"
           if [ ${{ inputs.test_dir }} != '' ]; then cd ${{ inputs.test_dir }}; fi
           eval $PYTEST_COMMAND
+
       - name: Show coverage
         run: |
           if [ ${{ inputs.test_dir }} != '' ]; then cd ${{ inputs.test_dir }}; fi


### PR DESCRIPTION
# Pull Request

## Description
Adds an optional `hf_token` input to the reusable `python-test` workflow and
exposes it as `HF_TOKEN` during pytest execution.

This allows CI jobs to authenticate with Hugging Face when needed, while
remaining fully optional and backwards compatible.



Fixes #86

## How Has This Been Tested?

This change was validated by reviewing the workflow configuration and ensuring
it remains backwards compatible.
The change is backwards compatible and does not alter CI behavior when
`hf_token` is not provided.


- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
