### PR TITLE
Create workflow for automated reply to internal issues

### DIFF
--- a/.github/workflows/internal-issue-comment.yml
+++ b/.github/workflows/internal-issue-comment.yml
@@ -1,0 +1,36 @@
+name: Reply to internal issue comment
+run-name: Reply to internal issue comment by ${{ github.actor }}
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  maybe-add-comment:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.issue.labels.*.name, 'contributions-welcome') && 
+        !contains(github.event.issue.labels.*.name, 'good first issue') && 
+        !github.event.issue.pull_request }}
+    permissions:
+      issues: write
+    steps:
+      - name: Check user not in core team
+        uses: tspascoal/get-user-teams-membership@v2
+        id: teamAffiliation
+        with:
+          GITHUB_TOKEN: ${{ secrets.OCF_BOT_PAT_TOKEN }}
+          username: ${{ github.event.comment.user.login }}
+          team: ocf-core
+      - name: Add comment
+        if: ${{ steps.teamAffiliation.outputs.isTeamMember == 'false' }}
+        run: |
+          gh issue comment "$NUMBER" --body  "@${{ github.event.comment.user.login }} $BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: >
+            Thank you for reaching out! Unfortunately, this issue is not suitable for open source 
+            contribution and so hasn't been marked with "good first issue" or "contributions welcome".
+            Please consult our [contribution guidelines](https://github.com/openclimatefix#how-to-get-involved) for more information on how you can contribute, 
+            and hope to see you around!

--- a/.github/workflows/internal-issue-comment.yml
+++ b/.github/workflows/internal-issue-comment.yml
@@ -35,7 +35,6 @@ jobs:
           gh issue comment "$NUMBER" --body  "@${{ github.event.comment.user.login }} $BODY"
         env:
           GH_TOKEN: ${{ secrets.OCF_BOT_PAT_TOKEN }}
-          GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
           BODY: >
             Thank you for reaching out! Unfortunately, this issue is not suitable for open source 

--- a/.github/workflows/internal-issue-comment.yml
+++ b/.github/workflows/internal-issue-comment.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check if user is in team
         id: check_team
         env:
-          GITHUB_TOKEN: ${{ secrets.OCF_BOT_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OCF_BOT_PAT_TOKEN }}
           USER: ${{ github.event.comment.user.login }}
         run: |
           is_member=$(gh api \
@@ -34,7 +34,7 @@ jobs:
         run: |
           gh issue comment "$NUMBER" --body  "@${{ github.event.comment.user.login }} $BODY"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OCF_BOT_PAT_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
           BODY: >

--- a/.github/workflows/internal-issue-comment.yml
+++ b/.github/workflows/internal-issue-comment.yml
@@ -13,15 +13,24 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Check user not in core team
-        uses: tspascoal/get-user-teams-membership@v2
-        id: teamAffiliation
-        with:
+      - name: Check if user is in team
+        id: check_team
+        env:
           GITHUB_TOKEN: ${{ secrets.OCF_BOT_PAT_TOKEN }}
-          username: ${{ github.event.comment.user.login }}
-          team: ocf-core
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          is_member=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /orgs/openclimatefix/teams/ocf-core/members \
+            --jq ".[] | select(.login == \"${USER}\") | .login")
+          
+          if [[ -n "$is_member" ]]; then
+            echo "is_member=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_member=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Add comment
-        if: ${{ steps.teamAffiliation.outputs.isTeamMember == 'false' }}
+        if: ${{ steps.check_team.outputs.is_member == 'false' }}
         run: |
           gh issue comment "$NUMBER" --body  "@${{ github.event.comment.user.login }} $BODY"
         env:

--- a/.github/workflows/internal-issue-comment.yml
+++ b/.github/workflows/internal-issue-comment.yml
@@ -1,14 +1,13 @@
 name: Reply to internal issue comment
 run-name: Reply to internal issue comment by ${{ github.actor }}
 on:
-  issue_comment:
-    types:
-      - created
+  workflow_call:
 
 jobs:
   comment-nocontribution:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.issue.labels.*.name, 'contributions-welcome') && 
+    if: ${{ contains(github.event_name, 'issue_comment') &&
+        !contains(github.event.issue.labels.*.name, 'contributions-welcome') && 
         !contains(github.event.issue.labels.*.name, 'good first issue') && 
         !github.event.issue.pull_request }}
     permissions:

--- a/.github/workflows/internal-issue-comment.yml
+++ b/.github/workflows/internal-issue-comment.yml
@@ -6,7 +6,7 @@ on:
       - created
 
 jobs:
-  maybe-add-comment:
+  comment-nocontribution:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.issue.labels.*.name, 'contributions-welcome') && 
         !contains(github.event.issue.labels.*.name, 'good first issue') && 


### PR DESCRIPTION
We get requests to assign open source contributors to internal issues. This workflow will let the ocf bot send an automated reply that this is not possible and direct to contribution guidelines.