### PR TITLE
add image_base_name to tagged_ci

### DIFF
--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -68,7 +68,7 @@ on:
       image_base_name:
         description: >
           Base name for the Docker image.
-        default:  ${{ github.repository }}
+        default:  ${{ github.repository_owner }} / ${{ github.repository }}
         required: false
         type: string
         

--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -67,8 +67,8 @@ on:
         type: string
       image_base_name:
         description: >
-          Base name for the Docker image.
-        default:  ${{ github.repository_owner }} / ${{ github.repository }}
+          Base name for the Docker image. It should start with 'openclimatefix/{name}'
+        default: ${{ github.repository }}
         required: false
         type: string
         

--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -65,6 +65,12 @@ on:
         default: '.'
         required: false
         type: string
+      image_base_name:
+        description: >
+          Base name for the Docker image.
+        default:  ${{ github.repository }}
+        required: false
+        type: string
         
 # Specify concurrency such that only one workflow can run at a time
 # * Different workflow files are not affected
@@ -74,7 +80,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ inputs.image_base_name }}
   UV_VERSION: "0.11.29"
   UV_LOCKED: 1
 

--- a/.github/workflows/tagged_ci.yml
+++ b/.github/workflows/tagged_ci.yml
@@ -21,6 +21,12 @@ on:
         default: false
         required: false
         type: boolean
+      image_base_name:
+        description: >
+          Base name for the Docker image.
+        default:  ${{ github.repository }}
+        required: false
+        type: string
 
 # Specify concurrency such that only one workflow can run at a time
 # * Different workflow files are not affected
@@ -30,7 +36,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ inputs.image_base_name }}
 
 
 jobs:

--- a/.github/workflows/tagged_ci.yml
+++ b/.github/workflows/tagged_ci.yml
@@ -23,8 +23,8 @@ on:
         type: boolean
       image_base_name:
         description: >
-          Base name for the Docker image.
-        default:  ${{ github.repository_owner }} / ${{ github.repository }}
+          Base name for the Docker image. It should start with 'openclimatefix/{name}'
+        default:  ${{ github.repository }}
         required: false
         type: string
 

--- a/.github/workflows/tagged_ci.yml
+++ b/.github/workflows/tagged_ci.yml
@@ -24,7 +24,7 @@ on:
       image_base_name:
         description: >
           Base name for the Docker image.
-        default:  ${{ github.repository }}
+        default:  ${{ github.repository_owner }} / ${{ github.repository }}
         required: false
         type: string
 


### PR DESCRIPTION
# Pull Request

## Description

Add an option to add your own image_base_name

We need this for pv-site-production where there are two different microservice / docker files being made

## How Has This Been Tested?

- [x] ran in https://github.com/openclimatefix/pv-site-production/pull/128

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
